### PR TITLE
Spread generation load and introduce series churn

### DIFF
--- a/src/cmd/promremotebench/write.go
+++ b/src/cmd/promremotebench/write.go
@@ -22,13 +22,12 @@ package main
 
 import (
 	"bufio"
-	"sync"
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"time"
 
@@ -42,22 +41,11 @@ import (
 
 func remoteWrite(series []*prompb.TimeSeries, remotePromClient *Client, remotePromBatchSize int) {
 	i := 0
-	wg := &sync.WaitGroup{}
 	for ; i < len(series)-remotePromBatchSize; i += remotePromBatchSize {
-		values := series[i:i+remotePromBatchSize]
-		wg.Add(1)
-		go func() {
-			remoteWriteBatch(values, remotePromClient)
-			wg.Done()
-		}()
+		remoteWriteBatch(series[i:i+remotePromBatchSize], remotePromClient)
 	}
 
-	// Write remainders
-	if len(series[i:]) > 0 {
-		remoteWriteBatch(series[i:], remotePromClient)
-	}
-
-	wg.Wait()
+	remoteWriteBatch(series[i:], remotePromClient)
 }
 
 func remoteWriteBatch(series []*prompb.TimeSeries, remotePromClient *Client) {

--- a/src/cmd/promremotebench/write_test.go
+++ b/src/cmd/promremotebench/write_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/golang/snappy"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemoteWrite(t *testing.T) {
@@ -105,7 +106,8 @@ func TestRemoteWrite(t *testing.T) {
 
 			hostGen := generators.NewHostsSimulator(test.numHosts, time.Now(),
 				generators.HostsSimulatorOptions{})
-			series := hostGen.Generate(time.Second, time.Second, 0)
+			series, err := hostGen.Generate(time.Second, time.Second, 0)
+			require.NoError(t, err)
 
 			batchSize := 10
 			expectedBatches := int(math.Ceil(float64(len(series)) / float64(batchSize)))

--- a/src/cmd/promremotebench/write_test.go
+++ b/src/cmd/promremotebench/write_test.go
@@ -21,7 +21,9 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -38,72 +40,83 @@ import (
 )
 
 func TestRemoteWrite(t *testing.T) {
-	numBatchesRecieved := 0
-	numTSRecieved := 0
-	var wg sync.WaitGroup
-
-	server := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			compressed, err := ioutil.ReadAll(r.Body)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-
-			reqBuf, err := snappy.Decode(nil, compressed)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-
-			var req prompb.WriteRequest
-			if err := proto.Unmarshal(reqBuf, &req); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-
-			numBatchesRecieved++
-			numTSRecieved += len(req.Timeseries)
-
-			wg.Done()
-		}),
-	)
-
-	serverURL, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name            string
+		numHosts        int
+		expectedBatches int
+		expectedSeries  int
+	}{
+		{
+			name:     "one host",
+			numHosts: 1,
+		},
+		{
+			name:     "eleven hosts",
+			numHosts: 11,
+		},
+		{
+			name:     "hundred hosts",
+			numHosts: 100,
+		},
 	}
 
-	remotePromClient, err := NewClient(serverURL.String(), time.Minute)
-	if err != nil {
-		t.Fatal(err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			numBatchesRecieved := 0
+			numTSRecieved := 0
+			var wg sync.WaitGroup
+
+			server := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					compressed, err := ioutil.ReadAll(r.Body)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusInternalServerError)
+						return
+					}
+
+					reqBuf, err := snappy.Decode(nil, compressed)
+					if err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+
+					var req prompb.WriteRequest
+					if err := proto.Unmarshal(reqBuf, &req); err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+
+					numBatchesRecieved++
+					numTSRecieved += len(req.Timeseries)
+
+					wg.Done()
+				}),
+			)
+
+			serverURL, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			remotePromClient, err := NewClient(serverURL.String(), time.Minute)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			hostGen := generators.NewHostsSimulator(test.numHosts, time.Now(),
+				generators.HostsSimulatorOptions{})
+			series := hostGen.Generate(time.Second, time.Second, 0)
+
+			batchSize := 10
+			expectedBatches := int(math.Ceil(float64(len(series)) / float64(batchSize)))
+
+			wg.Add(expectedBatches)
+			remoteWrite(series, remotePromClient, batchSize)
+			wg.Wait()
+			assert.Equal(t, expectedBatches, numBatchesRecieved)
+			assert.Equal(t, len(series), numTSRecieved)
+
+			fmt.Println("wrote series:", len(series))
+		})
 	}
-
-	hostGen := generators.NewHostsSimulator(1, 10, time.Now(), generators.HostsSimulatorOptions{})
-	series := hostGen.Generate(0, 0)
-	wg.Add(11)
-	remoteWrite(series, remotePromClient, 10)
-	wg.Wait()
-	assert.Equal(t, 11, numBatchesRecieved)
-	assert.Equal(t, 101, numTSRecieved)
-
-	numBatchesRecieved = 0
-	numTSRecieved = 0
-	hostGen = generators.NewHostsSimulator(11, 10, time.Now(), generators.HostsSimulatorOptions{})
-	series = hostGen.Generate(0, 0)
-	wg.Add(21)
-	remoteWrite(series, remotePromClient, 10)
-	wg.Wait()
-	assert.Equal(t, 21, numBatchesRecieved)
-	assert.Equal(t, 202, numTSRecieved)
-
-	numBatchesRecieved = 0
-	numTSRecieved = 0
-	hostGen = generators.NewHostsSimulator(100, 10, time.Now(), generators.HostsSimulatorOptions{})
-	series = hostGen.Generate(0, 0)
-	wg.Add(101)
-	remoteWrite(series, remotePromClient, 10)
-	wg.Wait()
-	assert.Equal(t, 101, numBatchesRecieved)
-	assert.Equal(t, 1010, numTSRecieved)
 }

--- a/src/go.mod
+++ b/src/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/prometheus/common v0.4.0
 	github.com/prometheus/prometheus v2.5.0+incompatible
 	github.com/stretchr/testify v1.2.2
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190516172635-bb713bdc0e52 // indirect
 	google.golang.org/grpc v1.20.1 // indirect
 )

--- a/src/go.mod
+++ b/src/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/prometheus/common v0.4.0
 	github.com/prometheus/prometheus v2.5.0+incompatible
 	github.com/stretchr/testify v1.2.2
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190516172635-bb713bdc0e52 // indirect
 	google.golang.org/grpc v1.20.1 // indirect
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,5 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -16,6 +17,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -32,8 +34,10 @@ github.com/influxdata/influxdb-comparisons v0.0.0-20190315104205-27ebcc6f3c08/go
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -56,6 +60,7 @@ github.com/prometheus/prometheus v2.5.0+incompatible h1:7QPitgO2kOFG8ecuRn9O/4L9
 github.com/prometheus/prometheus v2.5.0+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
@@ -81,6 +86,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -97,6 +103,7 @@ google.golang.org/grpc v1.20.1 h1:Hz2g2wirWK7H0qIIhGIqRGTuMwTE8HEKFnDZZ7lm9NU=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/src/pkg/generators/host_generator.go
+++ b/src/pkg/generators/host_generator.go
@@ -88,6 +88,10 @@ func (h *HostsSimulator) Generate(
 	now := time.Now()
 	factorProgress := float64(progressBy) / float64(scrapeDuration)
 	numHosts := int(math.Ceil(factorProgress * float64(len(h.allHosts))))
+	if numHosts == 0 {
+		// Always progress by at least one
+		numHosts = 1
+	}
 	if len(h.hosts) == 0 {
 		// Out of hosts, remove/add hosts as needed and progress ticking
 		for _, host := range h.allHosts {

--- a/src/pkg/generators/host_generator.go
+++ b/src/pkg/generators/host_generator.go
@@ -86,7 +86,7 @@ func (h *HostsSimulator) Generate(
 	}
 
 	now := time.Now()
-	numHosts := int(float64(progressBy/scrapeDuration) * float64(len(h.allHosts)))
+	numHosts := int(math.Ceil(float64(progressBy/scrapeDuration) * float64(len(h.allHosts))))
 	if len(h.hosts) == 0 {
 		// Out of hosts, remove/add hosts as needed and progress ticking
 		for _, host := range h.allHosts {

--- a/src/pkg/generators/host_generator.go
+++ b/src/pkg/generators/host_generator.go
@@ -75,7 +75,16 @@ func (h *HostsSimulator) Hosts() []devops.Host {
 	return append([]devops.Host{}, h.hosts...)
 }
 
-func (h *HostsSimulator) Generate(progressBy, scrapeDuration time.Duration, newSeriesPercent float64) []*prompb.TimeSeries {
+func (h *HostsSimulator) Generate(
+	progressBy, scrapeDuration time.Duration,
+	newSeriesPercent float64,
+) ([]*prompb.TimeSeries, error) {
+	if newSeriesPercent < 0 || newSeriesPercent > 1 {
+		return nil, fmt.Errorf(
+			"newSeriesPercent not between [0.0,1.0]: value=%v",
+			newSeriesPercent)
+	}
+
 	now := time.Now()
 	numHosts := int(float64(progressBy/scrapeDuration) * float64(len(h.allHosts)))
 	if len(h.hosts) == 0 {
@@ -156,5 +165,5 @@ func (h *HostsSimulator) Generate(progressBy, scrapeDuration time.Duration, newS
 		}
 	}
 
-	return allSeries
+	return allSeries, nil
 }

--- a/src/pkg/generators/host_generator.go
+++ b/src/pkg/generators/host_generator.go
@@ -86,7 +86,8 @@ func (h *HostsSimulator) Generate(
 	}
 
 	now := time.Now()
-	numHosts := int(math.Ceil(float64(progressBy/scrapeDuration) * float64(len(h.allHosts))))
+	factorProgress := float64(progressBy) / float64(scrapeDuration)
+	numHosts := int(math.Ceil(factorProgress * float64(len(h.allHosts))))
 	if len(h.hosts) == 0 {
 		// Out of hosts, remove/add hosts as needed and progress ticking
 		for _, host := range h.allHosts {

--- a/src/pkg/generators/host_generator.go
+++ b/src/pkg/generators/host_generator.go
@@ -22,6 +22,7 @@ package generators
 
 import (
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/influxdata/influxdb-comparisons/bulk_data_gen/common"
@@ -32,8 +33,9 @@ import (
 )
 
 type HostsSimulator struct {
-	hosts                 []devops.Host
-	appendLabels []*prompb.Label
+	hosts                 map[int][]*devops.Host
+	scrapeIntervalSeconds int
+	appendLabels          []*prompb.Label
 }
 
 type HostsSimulatorOptions struct {
@@ -41,92 +43,130 @@ type HostsSimulatorOptions struct {
 }
 
 func NewHostsSimulator(
-	hostCount int, 
+	hostCount, scrapeIntervalSeconds int,
 	start time.Time,
 	opts HostsSimulatorOptions,
 ) *HostsSimulator {
-	var hosts []devops.Host
+	hosts := make(map[int][]*devops.Host, scrapeIntervalSeconds)
+
+	for i := 0; i < scrapeIntervalSeconds; i++ {
+		hosts[i] = make([]*devops.Host, 0, hostCount/scrapeIntervalSeconds+1)
+	}
+
 	for i := 0; i < hostCount; i++ {
-		host := devops.NewHost(i, 0, start)
-		hosts = append(hosts, host)
+		intervalOffsetSeconds := i % scrapeIntervalSeconds
+		host := devops.NewHost(rand.Int(), rand.Int(), start.Add(time.Duration(intervalOffsetSeconds)*time.Second))
+		hosts[intervalOffsetSeconds] = append(hosts[i%scrapeIntervalSeconds], &host)
 	}
 
 	var appendLabels []*prompb.Label
 	if opts.Labels != nil {
 		for k, v := range opts.Labels {
 			appendLabels = append(appendLabels, &prompb.Label{
-				Name: k,
+				Name:  k,
 				Value: v,
 			})
 		}
 	}
 
 	return &HostsSimulator{
-		hosts: hosts,
-		appendLabels: appendLabels,
+		hosts:                 hosts,
+		scrapeIntervalSeconds: scrapeIntervalSeconds,
+		appendLabels:          appendLabels,
 	}
 }
 
-func (h *HostsSimulator) Hosts() []devops.Host {
-	return append([]devops.Host{}, h.hosts...)
+func (h *HostsSimulator) Hosts() []*devops.Host {
+	var allHosts []*devops.Host
+	for _, hosts := range h.hosts {
+		allHosts = append(allHosts, hosts...)
+	}
+
+	return allHosts
 }
 
-func (h *HostsSimulator) Generate(progressBy time.Duration) []*prompb.TimeSeries {
-	nowUnixMilliseconds := time.Now().UnixNano() / int64(time.Millisecond)
-	allSeries := make([]*prompb.TimeSeries, 0, len(h.hosts)*len(h.hosts[0].SimulatedMeasurements))
-	for _, host := range h.hosts {
-		if progressBy > 0 {
-			host.TickAll(progressBy)
+func (h *HostsSimulator) Generate(offsetSeconds int, newSeriesPercent float64) []*prompb.TimeSeries {
+	hosts := h.hosts[offsetSeconds]
+
+	if hosts == nil {
+		return nil
+	}
+
+	allSeries := make([]*prompb.TimeSeries, 0, len(hosts)*101)
+	hostsToRemove := map[*devops.Host]struct{}{}
+
+	for _, host := range hosts {
+		allSeries = appendMeasurements(host, allSeries, h.appendLabels)
+		if newSeriesPercent > 0 && rand.Float64()*100 < newSeriesPercent {
+			hostsToRemove[host] = struct{}{}
+			continue
 		}
 
-		for _, measurement := range host.SimulatedMeasurements {
-			p := common.MakeUsablePoint()
-			measurement.ToPoint(p)
+		host.TickAll(time.Duration(h.scrapeIntervalSeconds) * time.Second)
+	}
 
-			for i, fieldName := range p.FieldKeys {
-				val := 0.0
-
-				switch v := p.FieldValues[i].(type) {
-				case int:
-					val = float64(int(v))
-				case int64:
-					val = float64(int64(v))
-				case float64:
-					val = float64(v)
-				default:
-					panic(fmt.Sprintf("bad field %s with value type: %T with ", fieldName, v))
-				}
-
-				labels := []*prompb.Label{
-					&prompb.Label{Name: string(devops.MachineTagKeys[0]), Value: string(host.Name)},
-					&prompb.Label{Name: string(devops.MachineTagKeys[1]), Value: string(host.Region)},
-					&prompb.Label{Name: string(devops.MachineTagKeys[2]), Value: string(host.Datacenter)},
-					&prompb.Label{Name: string(devops.MachineTagKeys[3]), Value: string(host.Rack)},
-					&prompb.Label{Name: string(devops.MachineTagKeys[4]), Value: string(host.OS)},
-					&prompb.Label{Name: string(devops.MachineTagKeys[5]), Value: string(host.Arch)},
-					&prompb.Label{Name: string(devops.MachineTagKeys[6]), Value: string(host.Team)},
-					&prompb.Label{Name: string(devops.MachineTagKeys[7]), Value: string(host.Service)},
-					&prompb.Label{Name: string(devops.MachineTagKeys[8]), Value: string(host.ServiceVersion)},
-					&prompb.Label{Name: string(devops.MachineTagKeys[9]), Value: string(host.ServiceEnvironment)},
-					&prompb.Label{Name: "measurement", Value: string(fieldName)},
-					&prompb.Label{Name: labels.MetricName, Value: string(p.MeasurementName)},
-				}
-				if len(h.appendLabels) > 0 {
-					labels = append(labels, h.appendLabels...)
-				}
-
-				sample := prompb.Sample{
-					Value:     val,
-					Timestamp: nowUnixMilliseconds,
-				}
-
-				allSeries = append(allSeries, &prompb.TimeSeries{
-					Labels:  labels,
-					Samples: []prompb.Sample{sample},
-				})
+	if len(hostsToRemove) > 0 {
+		for i, host := range hosts {
+			if _, exists := hostsToRemove[host]; exists {
+				newHost := devops.NewHost(rand.Int(), rand.Int(), time.Now())
+				newHost.TickAll((time.Duration(h.scrapeIntervalSeconds) * time.Second))
+				hosts[i] = &newHost
 			}
 		}
 	}
 
 	return allSeries
+}
+
+func appendMeasurements(host *devops.Host, series []*prompb.TimeSeries, appendLabels []*prompb.Label) []*prompb.TimeSeries {
+	for _, measurement := range host.SimulatedMeasurements {
+		p := common.MakeUsablePoint()
+		measurement.ToPoint(p)
+
+		for i, fieldName := range p.FieldKeys {
+			val := 0.0
+
+			switch v := p.FieldValues[i].(type) {
+			case int:
+				val = float64(int(v))
+			case int64:
+				val = float64(int64(v))
+			case float64:
+				val = float64(v)
+			default:
+				panic(fmt.Sprintf("Cannot field %s with value type: %T with ", fieldName, v))
+			}
+
+			labels := []*prompb.Label{
+				&prompb.Label{Name: string(devops.MachineTagKeys[0]), Value: string(host.Name)},
+				&prompb.Label{Name: string(devops.MachineTagKeys[1]), Value: string(host.Region)},
+				&prompb.Label{Name: string(devops.MachineTagKeys[2]), Value: string(host.Datacenter)},
+				&prompb.Label{Name: string(devops.MachineTagKeys[3]), Value: string(host.Rack)},
+				&prompb.Label{Name: string(devops.MachineTagKeys[4]), Value: string(host.OS)},
+				&prompb.Label{Name: string(devops.MachineTagKeys[5]), Value: string(host.Arch)},
+				&prompb.Label{Name: string(devops.MachineTagKeys[6]), Value: string(host.Team)},
+				&prompb.Label{Name: string(devops.MachineTagKeys[7]), Value: string(host.Service)},
+				&prompb.Label{Name: string(devops.MachineTagKeys[8]), Value: string(host.ServiceVersion)},
+				&prompb.Label{Name: string(devops.MachineTagKeys[9]), Value: string(host.ServiceEnvironment)},
+				&prompb.Label{Name: "measurement", Value: string(fieldName)},
+				&prompb.Label{Name: labels.MetricName, Value: string(p.MeasurementName)},
+			}
+
+			if len(appendLabels) > 0 {
+				labels = append(labels, appendLabels...)
+			}
+
+			sample := prompb.Sample{
+				Value:     val,
+				Timestamp: p.Timestamp.UnixNano() / int64(time.Millisecond),
+			}
+
+			series = append(series, &prompb.TimeSeries{
+				Labels:  labels,
+				Samples: []prompb.Sample{sample},
+			})
+		}
+	}
+
+	return series
 }

--- a/src/pkg/generators/host_generator_test.go
+++ b/src/pkg/generators/host_generator_test.go
@@ -29,8 +29,28 @@ import (
 
 func TestHostsSimulator(t *testing.T) {
 	start := time.Now()
-	s := NewHostsSimulator(1, start, HostsSimulatorOptions{})
+	s := NewHostsSimulator(1, 5, start, HostsSimulatorOptions{})
 
-	series := s.Generate(0)
-	assert.True(t, len(series) > 0)
+	assert.Equal(t, 0, len(s.Generate(1, 0)))
+	assert.Equal(t, 0, len(s.Generate(2, 0)))
+	assert.Equal(t, 0, len(s.Generate(3, 0)))
+	assert.Equal(t, 0, len(s.Generate(4, 0)))
+	assert.Equal(t, 0, len(s.Generate(5, 0)))
+	assert.Equal(t, 0, len(s.Generate(6, 0)))
+	assert.Equal(t, 0, len(s.Generate(7, 0)))
+
+	series := s.Generate(0, 0)
+	assert.Equal(t, 101, len(series))
+
+	newSeries := s.Generate(0, 0)
+	assert.Equal(t, 101, len(newSeries))
+	assert.Equal(t, series[0].Labels, newSeries[0].Labels)
+
+	newSeries = s.Generate(0, 100)
+	assert.Equal(t, 101, len(newSeries))
+	assert.Equal(t, series[0].Labels, newSeries[0].Labels)
+
+	newSeries = s.Generate(0, 100)
+	assert.Equal(t, 101, len(newSeries))
+	assert.NotEqual(t, series[0].Labels, newSeries[0].Labels)
 }

--- a/src/pkg/generators/host_generator_test.go
+++ b/src/pkg/generators/host_generator_test.go
@@ -32,9 +32,19 @@ func TestHostsSimulator(t *testing.T) {
 	start := time.Now()
 	s := NewHostsSimulator(1, start, HostsSimulatorOptions{})
 
-	series, err := s.Generate(time.Second, time.Second, 0)
-	require.NoError(t, err)
-	assert.True(t, len(series) > 0)
+	{
+		// Without offset
+		series, err := s.Generate(0, time.Second, 0)
+		require.NoError(t, err)
+		assert.True(t, len(series) > 0)
+	}
+
+	{
+		// With offset
+		series, err := s.Generate(time.Second, time.Second, 0)
+		require.NoError(t, err)
+		assert.True(t, len(series) > 0)
+	}
 }
 
 func TestHostsSimulatorTenSeconds(t *testing.T) {

--- a/src/pkg/generators/host_generator_test.go
+++ b/src/pkg/generators/host_generator_test.go
@@ -36,3 +36,13 @@ func TestHostsSimulator(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, len(series) > 0)
 }
+
+func TestHostsSimulatorTenSeconds(t *testing.T) {
+	start := time.Now()
+	s := NewHostsSimulator(13, start, HostsSimulatorOptions{})
+	for i := 0; i < 100; i++ {
+		series, err := s.Generate(time.Second, 10*time.Second, 0.01)
+		require.NoError(t, err)
+		assert.True(t, len(series) > 0)
+	}
+}

--- a/src/pkg/generators/host_generator_test.go
+++ b/src/pkg/generators/host_generator_test.go
@@ -29,28 +29,8 @@ import (
 
 func TestHostsSimulator(t *testing.T) {
 	start := time.Now()
-	s := NewHostsSimulator(1, 5, start, HostsSimulatorOptions{})
+	s := NewHostsSimulator(1, start, HostsSimulatorOptions{})
 
-	assert.Equal(t, 0, len(s.Generate(1, 0)))
-	assert.Equal(t, 0, len(s.Generate(2, 0)))
-	assert.Equal(t, 0, len(s.Generate(3, 0)))
-	assert.Equal(t, 0, len(s.Generate(4, 0)))
-	assert.Equal(t, 0, len(s.Generate(5, 0)))
-	assert.Equal(t, 0, len(s.Generate(6, 0)))
-	assert.Equal(t, 0, len(s.Generate(7, 0)))
-
-	series := s.Generate(0, 0)
-	assert.Equal(t, 101, len(series))
-
-	newSeries := s.Generate(0, 0)
-	assert.Equal(t, 101, len(newSeries))
-	assert.Equal(t, series[0].Labels, newSeries[0].Labels)
-
-	newSeries = s.Generate(0, 100)
-	assert.Equal(t, 101, len(newSeries))
-	assert.Equal(t, series[0].Labels, newSeries[0].Labels)
-
-	newSeries = s.Generate(0, 100)
-	assert.Equal(t, 101, len(newSeries))
-	assert.NotEqual(t, series[0].Labels, newSeries[0].Labels)
+	series := s.Generate(time.Second, time.Second, 0)
+	assert.True(t, len(series) > 0)
 }

--- a/src/pkg/generators/host_generator_test.go
+++ b/src/pkg/generators/host_generator_test.go
@@ -25,12 +25,14 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHostsSimulator(t *testing.T) {
 	start := time.Now()
 	s := NewHostsSimulator(1, start, HostsSimulatorOptions{})
 
-	series := s.Generate(time.Second, time.Second, 0)
+	series, err := s.Generate(time.Second, time.Second, 0)
+	require.NoError(t, err)
 	assert.True(t, len(series) > 0)
 }


### PR DESCRIPTION
Spreading the generation of metrics from simulated hosts across the scrape interval while keeping a consistent interval per host. 

Also added an option to specify series churn where old hosts will be replaced by new hosts, keeping the overall number of time series produced, but introducing new series periodically. 