### PR TITLE
Probabilistic churn of generated time series

### DIFF
--- a/src/cmd/promremotebench/main.go
+++ b/src/cmd/promremotebench/main.go
@@ -473,7 +473,7 @@ func main() {
 			ColdWritesRange:   *coldWritesRange,
 		}
 
-		hostGen = generators.NewHostsSimulator(*numHosts, now, hostSimOpts, logger)
+		hostGen = generators.NewHostsSimulator(*numHosts, now, hostSimOpts)
 	)
 
 	client, err := NewClient(writeTargetURLs, time.Minute, scope.SubScope("writes"))

--- a/src/cmd/promremotebench/main.go
+++ b/src/cmd/promremotebench/main.go
@@ -473,7 +473,7 @@ func main() {
 			ColdWritesRange:   *coldWritesRange,
 		}
 
-		hostGen = generators.NewHostsSimulator(*numHosts, now, hostSimOpts)
+		hostGen = generators.NewHostsSimulator(*numHosts, now, hostSimOpts, logger)
 	)
 
 	client, err := NewClient(writeTargetURLs, time.Minute, scope.SubScope("writes"))

--- a/src/pkg/generators/host_generator.go
+++ b/src/pkg/generators/host_generator.go
@@ -135,7 +135,7 @@ func (h *hostsSimulator) Generate(
 			remove := int(math.Ceil(newSeriesPercent * float64(len(h.allHosts))))
 			h.logger.Info("removing series",
 				zap.Float64("newSeriesPercent", newSeriesPercent),
-				zap.Int("len(allHosts)", len(h.allHosts)),
+				zap.Int("len(h.allHosts)", len(h.allHosts)),
 				zap.Int("remove", remove))
 			h.allHosts = h.allHosts[:len(h.allHosts)-remove]
 			for i := 0; i < remove; i++ {


### PR DESCRIPTION
Because of formula `remove := int(math.Ceil(newSeriesPercent * float64(len(h.allHosts))))`, there was always at least one host removed during every scrape cycle. In practice, when using a typical number of hosts (100), this meant that the churn was at least 1% every scrape interval (which is huge), even though the value of `newSeriesPercent` was much smaller.
Also, only the last entry(-ies) of `h.allHosts` could churn, resulting in 99% of time series being stable, and 1% churning very often (in practice, after emitting just a single datapoint).
This PR introduces probabilistic churn of generated time series which allows to control the churn to an arbitrary precision (e.g. allowing sub-percent values), and makes it possible for any time series to churn. 